### PR TITLE
Dockerfile with base WLCG workernode configuration

### DIFF
--- a/wlcg-wn/Dockerfile
+++ b/wlcg-wn/Dockerfile
@@ -1,0 +1,17 @@
+FROM centos:7
+MAINTAINER Rene Caspart <rene.caspart@kit.edu>
+
+RUN yum update -y && yum clean -y all
+RUN yum install -y epel-release \
+                   https://linuxsoft.cern.ch/wlcg/centos7/x86_64/wlcg-repo-1.0.0-1.el7.noarch.rpm \
+                   http://repository.egi.eu/sw/production/umd/4/centos7/x86_64/updates/umd-release-4.1.3-1.el7.centos.noarch.rpm
+RUN yum update -y
+RUN yum install -y singularity cvmfs HEP_OSlibs wn tcsh && \
+    yum clean -y all
+
+RUN sed -i "s%allow setuid = yes%allow setuid = no%g" /etc/singularity/singularity.conf
+RUN sed -i "s%mount devpts = yes%mount devpts = no%g" /etc/singularity/singularity.conf
+
+RUN rm -rf /etc/grid-security/certificates && ln -s /cvmfs/grid.cern.ch/etc/grid-security/certificates/ /etc/grid-security/certificates
+
+RUN echo "export MACHINEFEATURES=/etc/machinefeatures" > /etc/profile.d/machinefeatures.sh


### PR DESCRIPTION
This PR adds an initial version of a Dockerfile suited to serve as workernode for all WLCG VOs.
It includes the singularity and cvmfs packages as well as the HEP_OSlibs (from the WLCG repository) and wn (from the UMD-4 repository) metapackages.
The container is defined to use the grid-security certificates from /cvmfs/grid.cern.ch/, which is required to be present in the environment the container is started in.