### PR TITLE
Optimisations corncerning `condor-git-config` environment

### DIFF
--- a/htcondor-wn/Dockerfile
+++ b/htcondor-wn/Dockerfile
@@ -23,7 +23,7 @@ RUN yum -y install epel-release && yum clean all
 RUN yum -y install condor \
                    python36 \
                    ansible \
-                   singularity \
+                   http://ekpwww.etp.kit.edu/~giffels/singularity-3.8.0-1.el7.x86_64.rpm \
                    tsocks \
      && yum clean all
 

--- a/htcondor-wn/Dockerfile
+++ b/htcondor-wn/Dockerfile
@@ -23,10 +23,15 @@ RUN yum -y install epel-release && yum clean all
 RUN yum -y install condor \
                    python36 \
                    ansible \
-                   git \
                    singularity \
                    tsocks \
      && yum clean all
+
+# Get a newer Git version to use Git Protocol v2 
+RUN yum -y install https://packages.endpoint.com/rhel/7/os/x86_64/endpoint-repo-1.9-1.x86_64.rpm \
+    && yum-config-manager --disable endpoint \
+    && yum -y install --enablerepo endpoint git \
+    && yum clean all
 
 RUN python3.6 -m pip install --no-cache-dir condor_git_config pexpect
 

--- a/htcondor-wn/README.md
+++ b/htcondor-wn/README.md
@@ -8,15 +8,16 @@ this image supports HTCondor's pool password and token authentication.
 In order to configure your worker node, you need to create a directory
 containing an yaml containing the supported ansible variables described below.
 
-| Variable                           | Description                                                                    |
-|------------------------------------|--------------------------------------------------------------------------------|
-| HTCONDOR_CONFIG_GIT_REPO           | URL pointing to the Git repository containing the HTCondor configuration       |
-| GIT_USER                           | Username to use when accessing the Git repository above                        |
-| GIT_TOKEN                          | Token/Password to use when accessing the Git repository above                  |
-| CLOUD_SITE_ID                      | We are using `condor-git-config` white listing to support multiple cloud sites |
-| HTCONDOR_POOL_PASSWORD (Optional)  | Pool password to authenticate the worker node with the HTCondor cluster         |
-| HTCONDOR_TOKEN (Optional)          | Token to authenticate the worker node against the HTCondor cluster              |
-| HTCONDOR_TOKEN_PASSWORD (Optional) | Token password to authenticate the HTCondor cluster against the worker node    |
+| Variable                           | Description                                                                          |
+|------------------------------------|--------------------------------------------------------------------------------------|
+| HTCONDOR_CONFIG_GIT_REPO           | URL pointing to the Git repository containing the HTCondor configuration             |
+| HTCONDOR_CONFIG_GIT_CACHE_PATH     | Cache path location on destination system (optional, default=/etc/condor/config.git) |
+| GIT_USER                           | Username to use when accessing the Git repository above                              |
+| GIT_TOKEN                          | Token/Password to use when accessing the Git repository above                        |
+| CLOUD_SITE_ID                      | We are using `condor-git-config` white listing to support multiple cloud sites       |
+| HTCONDOR_POOL_PASSWORD (Optional)  | Pool password to authenticate the worker node with the HTCondor cluster              |
+| HTCONDOR_TOKEN (Optional)          | Token to authenticate the worker node against the HTCondor cluster                   |
+| HTCONDOR_TOKEN_PASSWORD (Optional) | Token password to authenticate the HTCondor cluster against the worker node          |
 
 ## Example configurations
 

--- a/htcondor-wn/ansible_config/roles/git-credentials/tasks/main.yaml
+++ b/htcondor-wn/ansible_config/roles/git-credentials/tasks/main.yaml
@@ -2,7 +2,7 @@
   community.general.git_config:
     name: credential.helper
     scope: global
-    value: store
+    value: "store --file /scratch/.git-credentials"
   when: 
     - GIT_USER is defined
     - GIT_TOKEN is defined
@@ -15,7 +15,7 @@
     GIT_PORT: "{{ HTCONDOR_CONFIG_GIT_REPO | urlsplit('port') }}"
   template:
     src: git-credentials.j2
-    dest: "{{ ansible_env.HOME }}/.git-credentials"
+    dest: "/scratch/.git-credentials"
     mode: 0600
   when: 
     - GIT_USER is defined

--- a/htcondor-wn/ansible_config/roles/htcondor/templates/condor_config.local.j2
+++ b/htcondor-wn/ansible_config/roles/htcondor/templates/condor_config.local.j2
@@ -1,1 +1,1 @@
-include command : condor-git-config  {{ HTCONDOR_CONFIG_GIT_REPO }} --blacklist .*-cloud\.cfg --whitelist @{{ CLOUD_SITE_ID_FILE }}
+include command : condor-git-config  {{ HTCONDOR_CONFIG_GIT_REPO }} --cache-path {{ HTCONDOR_CONFIG_GIT_CACHE_PATH | default("/etc/condor/config.git/") }} --blacklist .*-cloud\.cfg --whitelist @{{ CLOUD_SITE_ID_FILE }}


### PR DESCRIPTION
This pull requests 

- make the `condor-git-config` `cache-path` configurable. 
- changes the default localtion of the git credentials to `/scratch`
- pins singularity version to 3.8.0 until fix for https://github.com/hpcng/singularity/issues/6165 has been propageted to EPEL
- Installs most recent git version