### PR TITLE
Make alternates set java command to work with minor version updates

### DIFF
--- a/wlcg-wn/Dockerfile
+++ b/wlcg-wn/Dockerfile
@@ -12,7 +12,7 @@ RUN yum install -y singularity cvmfs HEP_OSlibs wn tcsh && \
 # Fix for broken dcache-srmclient-6.2.24-1.noarch
 RUN yum install -y java-11-openjdk java-11-openjdk-devel java-11-openjdk-headless && \
     yum clean -y all
-RUN alternatives --set java /usr/lib/jvm/java-11-openjdk-11.0.12.0.7-0.el7_9.x86_64/bin/java
+RUN alternatives --set java $(find /usr/lib/jvm/java-11* -iname java -type f | head -n 1)
 
 RUN sed -i "s%allow setuid = yes%allow setuid = no%g" /etc/singularity/singularity.conf
 RUN sed -i "s%mount devpts = yes%mount devpts = no%g" /etc/singularity/singularity.conf


### PR DESCRIPTION
Docker builds are broken due to a minor java11 version upgrade. This pull requests makes set altenatives work with minor version upgrades.