### PR TITLE
Add support for base64 encoded tokens and work around for cuda libraries

### DIFF
--- a/htcondor-wn/Dockerfile
+++ b/htcondor-wn/Dockerfile
@@ -47,5 +47,7 @@ COPY ansible_config /srv/ansible_config
 COPY pilot_execute.sh /srv/pilot_execute.sh
 RUN chmod +x /srv/pilot_execute.sh
 
+COPY singularity_nv_setup.sh /etc/profile.d/singularity_nv_setup.sh
+
 WORKDIR /srv
 ENTRYPOINT ["/tini", "-s", "--", "/srv/pilot_execute.sh"]

--- a/htcondor-wn/Dockerfile
+++ b/htcondor-wn/Dockerfile
@@ -47,7 +47,8 @@ COPY ansible_config /srv/ansible_config
 COPY pilot_execute.sh /srv/pilot_execute.sh
 RUN chmod +x /srv/pilot_execute.sh
 
+COPY ldconfig_wrapper.sh /usr/local/bin/ldconfig
 COPY singularity_nv_setup.sh /etc/profile.d/singularity_nv_setup.sh
 
-WORKDIR /srv
+WORKDIR /scratch
 ENTRYPOINT ["/tini", "-s", "--", "/srv/pilot_execute.sh"]

--- a/htcondor-wn/Dockerfile
+++ b/htcondor-wn/Dockerfile
@@ -28,7 +28,7 @@ RUN yum -y install condor \
      && yum clean all
 
 # Get a newer Git version to use Git Protocol v2 
-RUN yum -y install https://packages.endpoint.com/rhel/7/os/x86_64/endpoint-repo-1.9-1.x86_64.rpm \
+RUN yum -y install https://packages.endpointdev.com/rhel/7/os/x86_64/endpoint-repo-1.10-1.x86_64.rpm \
     && yum-config-manager --disable endpoint \
     && yum -y install --enablerepo endpoint git \
     && yum clean all

--- a/htcondor-wn/README.md
+++ b/htcondor-wn/README.md
@@ -8,16 +8,16 @@ this image supports HTCondor's pool password and token authentication.
 In order to configure your worker node, you need to create a directory
 containing an yaml containing the supported ansible variables described below.
 
-| Variable                           | Description                                                                          |
-|------------------------------------|--------------------------------------------------------------------------------------|
-| HTCONDOR_CONFIG_GIT_REPO           | URL pointing to the Git repository containing the HTCondor configuration             |
-| HTCONDOR_CONFIG_GIT_CACHE_PATH     | Cache path location on destination system (optional, default=/etc/condor/config.git) |
-| GIT_USER                           | Username to use when accessing the Git repository above                              |
-| GIT_TOKEN                          | Token/Password to use when accessing the Git repository above                        |
-| CLOUD_SITE_ID                      | We are using `condor-git-config` white listing to support multiple cloud sites       |
-| HTCONDOR_POOL_PASSWORD (Optional)  | Pool password to authenticate the worker node with the HTCondor cluster              |
-| HTCONDOR_TOKEN (Optional)          | Token to authenticate the worker node against the HTCondor cluster                   |
-| HTCONDOR_TOKEN_PASSWORD (Optional) | Token password to authenticate the HTCondor cluster against the worker node          |
+| Variable                           | Description                                                                                                                |
+|------------------------------------|----------------------------------------------------------------------------------------------------------------------------|
+| HTCONDOR_CONFIG_GIT_REPO           | URL pointing to the Git repository containing the HTCondor configuration                                                   |
+| HTCONDOR_CONFIG_GIT_CACHE_PATH     | Cache path location on destination system (optional, default=/etc/condor/config.git)                                       |
+| GIT_USER                           | Username to use when accessing the Git repository above                                                                    |
+| GIT_TOKEN                          | Token/Password to use when accessing the Git repository above                                                              |
+| CLOUD_SITE_ID                      | We are using `condor-git-config` white listing to support multiple cloud sites                                             |
+| HTCONDOR_POOL_PASSWORD (Optional)  | Pool password to authenticate the worker node with the HTCondor cluster (optional base64 support for binary passwords)     |
+| HTCONDOR_TOKEN (Optional)          | Token to authenticate the worker node against the HTCondor cluster (optional base64 support for binary passwords)          |
+| HTCONDOR_TOKEN_PASSWORD (Optional) | Token password to authenticate the HTCondor cluster against the worker node (optional base64 support for binary passwords) |
 
 ## Example configurations
 

--- a/htcondor-wn/ansible_config/roles/htcondor/tasks/add_token.yaml
+++ b/htcondor-wn/ansible_config/roles/htcondor/tasks/add_token.yaml
@@ -2,8 +2,7 @@
   block:
   - name: Add base64 encoded tokens to the directories
     shell: |
-        echo '{{ item[0].value }}' | base64 --decode > {{ item[1] + item[0].key }}
-        chmod 0600 {{ item[1] + item[0].key }}
+        echo '{{ item[0].value }}' | base64 --decode > {{ item[1] + item[0].key }} && chmod 0600 {{ item[1] + item[0].key }}
   rescue:
   - name: Add tokens directly to the direcories
     copy:

--- a/htcondor-wn/ansible_config/roles/htcondor/tasks/add_token.yaml
+++ b/htcondor-wn/ansible_config/roles/htcondor/tasks/add_token.yaml
@@ -1,0 +1,12 @@
+- name: Add tokens to the directories
+  block:
+  - name: Add base64 encoded tokens to the directories
+    shell: |
+        echo '{{ item[0].value }}' | base64 --decode > {{ item[1] + item[0].key }}
+        chmod 0600 {{ item[1] + item[0].key }}
+  rescue:
+  - name: Add tokens directly to the direcories
+    copy:
+        dest: "{{ item[1] + item[0].key }}"
+        content: "{{ item[0].value }}"
+        mode: "0600"

--- a/htcondor-wn/ansible_config/roles/htcondor/tasks/add_token_password.yaml
+++ b/htcondor-wn/ansible_config/roles/htcondor/tasks/add_token_password.yaml
@@ -1,0 +1,12 @@
+- name: Add token password to directory
+  block:
+    - name: Add base64 encoded token passwords to directory
+      shell: |
+        echo '{{ item.value }}' | base64 --decode > {{ SEC_PASSWORD_DIRECTORY.stdout + item.key }}
+        chmod 0600 {{ SEC_PASSWORD_DIRECTORY.stdout + item.key }}
+  rescue:
+    - name: Add token passwords directly to directory
+      copy:
+        dest:  "{{ SEC_PASSWORD_DIRECTORY.stdout + item.key }}"
+        content: "{{ item.value }}"
+        mode: "0600"

--- a/htcondor-wn/ansible_config/roles/htcondor/tasks/add_token_password.yaml
+++ b/htcondor-wn/ansible_config/roles/htcondor/tasks/add_token_password.yaml
@@ -2,8 +2,7 @@
   block:
     - name: Add base64 encoded token passwords to directory
       shell: |
-        echo '{{ item.value }}' | base64 --decode > {{ SEC_PASSWORD_DIRECTORY.stdout + item.key }}
-        chmod 0600 {{ SEC_PASSWORD_DIRECTORY.stdout + item.key }}
+        echo '{{ item.value }}' | base64 --decode > {{ SEC_PASSWORD_DIRECTORY.stdout + item.key }} && chmod 0600 {{ SEC_PASSWORD_DIRECTORY.stdout + item.key }}
   rescue:
     - name: Add token passwords directly to directory
       copy:

--- a/htcondor-wn/ansible_config/roles/htcondor/tasks/password_auth.yaml
+++ b/htcondor-wn/ansible_config/roles/htcondor/tasks/password_auth.yaml
@@ -11,10 +11,22 @@
     mode: 0755
 
 - name: Add HTCondor Pool Password
-  copy:
-    dest: "{{ SEC_PASSWORD_FILE.stdout }}"
-    content: "{{ HTCONDOR_POOL_PASSWORD }}"
-    mode: 0600
+  block:
+    - name: Add HTCondor Base64 encoded Pool Password
+      shell: |
+        echo '{{ HTCONDOR_POOL_PASSWORD }}' | base64 --decode > {{ SEC_PASSWORD_FILE.stdout }}
+        chmod 0600 {{ SEC_PASSWORD_FILE.stdout }}
+      # does not work in python2.7 on centos7
+      #copy:
+      #  dest: "{{ SEC_PASSWORD_FILE.stdout }}"
+      #  content: "{{ HTCONDOR_POOL_PASSWORD | b64decode }}"
+      #  mode: 0600
+  rescue:
+    - name: Add HTCondor Pool Password String
+      copy:
+        dest: "{{ SEC_PASSWORD_FILE.stdout }}"
+        content: "{{ HTCONDOR_POOL_PASSWORD }}"
+        mode: 0600
 
 #- name: Add HTCondor Pool Password
 #  vars:

--- a/htcondor-wn/ansible_config/roles/htcondor/tasks/token_auth.yaml
+++ b/htcondor-wn/ansible_config/roles/htcondor/tasks/token_auth.yaml
@@ -59,17 +59,7 @@
     - item[1] | length > 0
 
 - name: Add token passwords to directory
-  block:
-    - name: Add base64 encoded token passwords to directory
-      shell: |
-        echo '{{ item.value }}' | base64 --decode > {{ SEC_PASSWORD_DIRECTORY.stdout + item.key }}
-        chmod 0600 {{ SEC_PASSWORD_DIRECTORY.stdout + item.key }}
-  rescue:
-    - name: Add token passwords directly to directory
-      copy:
-        dest:  "{{ SEC_PASSWORD_DIRECTORY.stdout + item.key }}"
-        content: "{{ item.value }}"
-        mode: "0600"
+  include_tasks: add_token_password.yaml
   loop: "{{ HTCONDOR_TOKEN_PASSWORD | dict2items }}"
   loop_control:
     label: "Adding token password to {{ SEC_PASSWORD_DIRECTORY.stdout + item.key }}"

--- a/htcondor-wn/ansible_config/roles/htcondor/tasks/token_auth.yaml
+++ b/htcondor-wn/ansible_config/roles/htcondor/tasks/token_auth.yaml
@@ -47,10 +47,7 @@
     directories:
       - "{{ SEC_TOKEN_SYSTEM_DIRECTORY.stdout }}"
       - "{{ SEC_TOKEN_DIRECTORY.stdout }}"
-  copy:
-    dest: "{{ item[1] + item[0].key }}"
-    content: "{{ item[0].value }}"
-    mode: "0600"
+  include_tasks: add_token.yaml
   loop: "{{ HTCONDOR_TOKEN | dict2items | product(directories)|list }}"
   loop_control:
     label: "Adding tokens to {{ item[1] }}"

--- a/htcondor-wn/ansible_config/roles/htcondor/tasks/token_auth.yaml
+++ b/htcondor-wn/ansible_config/roles/htcondor/tasks/token_auth.yaml
@@ -59,10 +59,17 @@
     - item[1] | length > 0
 
 - name: Add token passwords to directory
-  copy:
-    dest:  "{{ SEC_PASSWORD_DIRECTORY.stdout + item.key }}"
-    content: "{{ item.value }}"
-    mode: "0600"
+  block:
+    - name: Add base64 encoded token passwords to directory
+      shell: |
+        echo '{{ item.value }}' | base64 --decode > {{ SEC_PASSWORD_DIRECTORY.stdout + item.key }}
+        chmod 0600 {{ SEC_PASSWORD_DIRECTORY.stdout + item.key }}
+  rescue:
+    - name: Add token passwords directly to directory
+      copy:
+        dest:  "{{ SEC_PASSWORD_DIRECTORY.stdout + item.key }}"
+        content: "{{ item.value }}"
+        mode: "0600"
   loop: "{{ HTCONDOR_TOKEN_PASSWORD | dict2items }}"
   loop_control:
     label: "Adding token password to {{ SEC_PASSWORD_DIRECTORY.stdout + item.key }}"

--- a/htcondor-wn/ldconfig_wrapper.sh
+++ b/htcondor-wn/ldconfig_wrapper.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+/sbin/ldconfig -C /scratch/ld.so.cache "$@"

--- a/htcondor-wn/pilot_execute.sh
+++ b/htcondor-wn/pilot_execute.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/bin/bash -l
 cd /srv/ansible_config && ansible-playbook -i hosts.ini container_config.yaml && cd /srv && condor_master -f

--- a/htcondor-wn/singularity_nv_setup.sh
+++ b/htcondor-wn/singularity_nv_setup.sh
@@ -7,11 +7,10 @@ TMPD=$(mktemp -d)
 
 cat << EOF > ${TMPD}/ldconfig
 #!/bin/bash
-exec /usr/sbin/ldconfig -C ${TMPD}/ld.so.cache \$@ > ${TMPD}/ldconfig
+exec /usr/sbin/ldconfig -C ${TMPD}/ld.so.cache \$@
 EOF
 
 chmod +x ${TMPD}/ldconfig
 
 PATH=${TMPD}:${PATH}
 ldconfig ${LD_LIBRARY_PATH}
-

--- a/htcondor-wn/singularity_nv_setup.sh
+++ b/htcondor-wn/singularity_nv_setup.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# --nv flag does not work in nested singularity containers
+# this workaround ensures that --nv even works in nested singularity containers
+# details can be found in https://github.com/apptainer/singularity/issues/5759 
+
+TMPD=$(mktemp -d)
+
+cat << EOF > ${TMPD}/ldconfig
+#!/bin/bash
+exec /usr/sbin/ldconfig -C ${TMPD}/ld.so.cache \$@ > ${TMPD}/ldconfig
+EOF
+
+chmod +x ${TMPD}/ldconfig
+
+PATH=${TMPD}:${PATH}
+ldconfig ${LD_LIBRARY_PATH}
+

--- a/htcondor-wn/singularity_nv_setup.sh
+++ b/htcondor-wn/singularity_nv_setup.sh
@@ -3,14 +3,5 @@
 # this workaround ensures that --nv even works in nested singularity containers
 # details can be found in https://github.com/apptainer/singularity/issues/5759 
 
-TMPD=$(mktemp -d)
-
-cat << EOF > ${TMPD}/ldconfig
-#!/bin/bash
-exec /usr/sbin/ldconfig -C ${TMPD}/ld.so.cache \$@
-EOF
-
-chmod +x ${TMPD}/ldconfig
-
-PATH=${TMPD}:${PATH}
-ldconfig ${LD_LIBRARY_PATH}
+[[ :$LD_LIBRARY_PATH: == *":/.singularity.d/libs:"* ]] || LD_LIBRARY_PATH=/.singularity.d/libs:${LD_LIBRARY_PATH}
+/usr/local/bin/ldconfig /.singularity.d/libs

--- a/wlcg-wn/Dockerfile
+++ b/wlcg-wn/Dockerfile
@@ -26,4 +26,5 @@ RUN echo "export VO_BELLE_SW_DIR=/cvmfs/belle.cern.ch/sl6" >> /etc/profile.d/gri
 RUN echo "export VO_CMS_SW_DIR=/cvmfs/cms.cern.ch" >> /etc/profile.d/grid_env.sh
 RUN echo "export VO_LHCB_SW_DIR=/cvmfs/lhcb.cern.ch" >> /etc/profile.d/grid_env.sh
 
+COPY ldconfig_wrapper.sh /usr/local/bin/ldconfig
 COPY singularity_nv_setup.sh /etc/profile.d/singularity_nv_setup.sh

--- a/wlcg-wn/Dockerfile
+++ b/wlcg-wn/Dockerfile
@@ -25,3 +25,5 @@ RUN echo "export VO_AUGER_SW_DIR=/cvmfs/auger.egi.eu" >> /etc/profile.d/grid_env
 RUN echo "export VO_BELLE_SW_DIR=/cvmfs/belle.cern.ch/sl6" >> /etc/profile.d/grid_env.sh
 RUN echo "export VO_CMS_SW_DIR=/cvmfs/cms.cern.ch" >> /etc/profile.d/grid_env.sh
 RUN echo "export VO_LHCB_SW_DIR=/cvmfs/lhcb.cern.ch" >> /etc/profile.d/grid_env.sh
+
+COPY singularity_nv_setup.sh /etc/profile.d/singularity_nv_setup.sh

--- a/wlcg-wn/ldconfig_wrapper.sh
+++ b/wlcg-wn/ldconfig_wrapper.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+/sbin/ldconfig -C /srv/ld.so.cache "$@"

--- a/wlcg-wn/singularity_nv_setup.sh
+++ b/wlcg-wn/singularity_nv_setup.sh
@@ -7,11 +7,10 @@ TMPD=$(mktemp -d)
 
 cat << EOF > ${TMPD}/ldconfig
 #!/bin/bash
-exec /usr/sbin/ldconfig -C ${TMPD}/ld.so.cache \$@ > ${TMPD}/ldconfig
+exec /usr/sbin/ldconfig -C ${TMPD}/ld.so.cache \$@
 EOF
 
 chmod +x ${TMPD}/ldconfig
 
 PATH=${TMPD}:${PATH}
 ldconfig ${LD_LIBRARY_PATH}
-

--- a/wlcg-wn/singularity_nv_setup.sh
+++ b/wlcg-wn/singularity_nv_setup.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# --nv flag does not work in nested singularity containers
+# this workaround ensures that --nv even works in nested singularity containers
+# details can be found in https://github.com/apptainer/singularity/issues/5759 
+
+TMPD=$(mktemp -d)
+
+cat << EOF > ${TMPD}/ldconfig
+#!/bin/bash
+exec /usr/sbin/ldconfig -C ${TMPD}/ld.so.cache \$@ > ${TMPD}/ldconfig
+EOF
+
+chmod +x ${TMPD}/ldconfig
+
+PATH=${TMPD}:${PATH}
+ldconfig ${LD_LIBRARY_PATH}
+

--- a/wlcg-wn/singularity_nv_setup.sh
+++ b/wlcg-wn/singularity_nv_setup.sh
@@ -3,14 +3,5 @@
 # this workaround ensures that --nv even works in nested singularity containers
 # details can be found in https://github.com/apptainer/singularity/issues/5759 
 
-TMPD=$(mktemp -d)
-
-cat << EOF > ${TMPD}/ldconfig
-#!/bin/bash
-exec /usr/sbin/ldconfig -C ${TMPD}/ld.so.cache \$@
-EOF
-
-chmod +x ${TMPD}/ldconfig
-
-PATH=${TMPD}:${PATH}
-ldconfig ${LD_LIBRARY_PATH}
+[[ :$LD_LIBRARY_PATH: == *":/.singularity.d/libs:"* ]] || LD_LIBRARY_PATH=/.singularity.d/libs:${LD_LIBRARY_PATH}
+/usr/local/bin/ldconfig /.singularity.d/libs


### PR DESCRIPTION
This pull request adds the following features

- [x] Support for base64 encoded HTCondor pool passwords, since they can contain binary values
- [x] Support for base64 encoded HTCondor tokens and token passwords, same reason as above
- [x] A work-around to allow for using the `--nv` flag in nested Singularity containers. (see https://github.com/apptainer/singularity/issues/5759 for details)

In addition, the version of the endpoint repository used to deploy a recent git version has been bumped to version `1.10-1`.