### PR TITLE
Fix ansible module name

### DIFF
--- a/htcondor-wn/ansible_config/roles/git-credentials/tasks/main.yaml
+++ b/htcondor-wn/ansible_config/roles/git-credentials/tasks/main.yaml
@@ -1,5 +1,5 @@
 - name: Add credential store to global gitconfig
-  community.general.git_config:
+  git_config:
     name: credential.helper
     scope: global
     value: "store --file /scratch/.git-credentials"


### PR DESCRIPTION
Ansible module name `community.general.git_config` does not work anymore. 
```
ERROR! couldn't resolve module/action 'community.general.git_config'. This often indicates a misspelling, missing collection, or incorrect module path.

The error appears to be in '/srv/ansible_config/roles/git-credentials/tasks/main.yaml': line 1, column 3, but may
be elsewhere in the file depending on the exact syntax problem.
```
According to the [git_config module documentation](https://docs.ansible.com/ansible/2.9/modules/git_config_module.html) `git_config` should be used and was tested.