### PR TITLE
Add condor_ssh_to_job_template

### DIFF
--- a/htcondor-wn/ansible_config/roles/htcondor/tasks/config.yaml
+++ b/htcondor-wn/ansible_config/roles/htcondor/tasks/config.yaml
@@ -36,9 +36,8 @@
     - CLOUD_SITE_ID is defined
     - HTCONDOR_CONFIG_GIT_REPO is defined
 
-- name: Remove /etc/condor/condor_ssh_to_job_sshd_config_template
-  file:
-    path: /etc/condor/condor_ssh_to_job_sshd_config_template
-    state: absent
-  when: 
-    - HTCONDOR_CONFIG_GIT_REPO is defined
+- name: Create link to condor_ssh_to_job_sshd_config_template
+  ansible.builtin.file:
+    src: /usr/lib64/condor/condor_ssh_to_job_sshd_config_template
+    dest: /etc/condor/condor_ssh_to_job_sshd_config_template
+    state: link


### PR DESCRIPTION
Add a link to the `condor_ssh_to_job_template` to `/etc/condor` in order to use `condor_ssh_to_job`.