### PR TITLE
Fix pseudoterminal in unpriv. namespace

### DIFF
--- a/wlcg-wn/Dockerfile
+++ b/wlcg-wn/Dockerfile
@@ -9,6 +9,9 @@ RUN yum update -y
 RUN yum install -y apptainer cvmfs HEP_OSlibs wn tcsh && \
     yum clean -y all
 
+# Fix pseudoterminal in unpriv. namespace; see https://github.com/apptainer/apptainer/issues/297
+RUN yum install -y glibc-grantpt-fix
+
 # Fix for broken dcache-srmclient-6.2.24-1.noarch
 RUN yum install -y java-11-openjdk java-11-openjdk-devel java-11-openjdk-headless && \
     yum clean -y all

--- a/wlcg-wn/Dockerfile
+++ b/wlcg-wn/Dockerfile
@@ -10,7 +10,8 @@ RUN yum install -y apptainer cvmfs HEP_OSlibs wn tcsh && \
     yum clean -y all
 
 # Fix pseudoterminal in unpriv. namespace; see https://github.com/apptainer/apptainer/issues/297
-RUN yum install -y glibc-grantpt-fix
+RUN yum install -y glibc-grantpt-fix && \
+    yum clean -y all
 
 # Fix for broken dcache-srmclient-6.2.24-1.noarch
 RUN yum install -y java-11-openjdk java-11-openjdk-devel java-11-openjdk-headless && \


### PR DESCRIPTION
Some CMS SAM test requires a pseudoterminal. This does not work within a container with the glibc version used in CentOS7; see https://github.com/apptainer/apptainer/issues/297 CERN provides a patch for glibc to fix it via the `glibc-grantpt-fix` from the `wlcg` repository.