### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/docker_builds.yml
+++ b/.github/workflows/docker_builds.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Get containers to build
         id: get_containers
-        run: python3 -c 'import json; import os; print("::set-output name=containers::%s" % json.dumps([os.path.normpath(dirpath) for dirpath, dirnames, filenames in os.walk(".") if "Dockerfile" in filenames]))'
+        run: python3 -c 'import json; import os; print("containers=%s" % json.dumps([os.path.normpath(dirpath) for dirpath, dirnames, filenames in os.walk(".") if "Dockerfile" in filenames]))' >> $GITHUB_OUTPUT
     outputs:
       containers: ${{ steps.get_containers.outputs.containers }}
 

--- a/.github/workflows/docker_builds.yml
+++ b/.github/workflows/docker_builds.yml
@@ -10,7 +10,7 @@ jobs:
   setup-docker-builds:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Get containers to build
         id: get_containers
         run: python3 -c 'import json; import os; print("::set-output name=containers::%s" % json.dumps([os.path.normpath(dirpath) for dirpath, dirnames, filenames in os.walk(".") if "Dockerfile" in filenames]))'
@@ -25,16 +25,16 @@ jobs:
         containers: ${{ fromJSON(needs.setup-docker-builds.outputs.containers) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Get current date
         id: get_date
         run: |
           echo "current_date=$(date +%Y%m%d)" >> $GITHUB_ENV
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: matterminers/${{ matrix.containers }}
           flavor: |
@@ -43,13 +43,13 @@ jobs:
             type=raw,value=${{ env.current_date }}
       - name: Login to DockerHub
         if: github.repository == 'MatterMiners/container-stacks' && github.ref == 'refs/heads/main'
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: ${{ matrix.containers }}
           push: ${{ github.repository == 'MatterMiners/container-stacks' && github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
Fixes the following warnings:

- [x] Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2
- [x] The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files.