### PR TITLE
Upgrade htcondor-wn to use RockyLinux 8 and HTCondor 10

### DIFF
--- a/htcondor-wn/Dockerfile
+++ b/htcondor-wn/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7
+FROM rockylinux:8
 LABEL maintainer="Manuel Giffels <giffels@gmail.com>"
 
 # Create links to point to scratch directory
@@ -17,24 +17,24 @@ RUN ln -s /scratch/var/lock/condor /var/lock/condor
 RUN ln -s /scratch/var/run/condor /var/run/condor
 
 RUN rpm --import http://research.cs.wisc.edu/htcondor/yum/RPM-GPG-KEY-HTCondor
-RUN yum install -y https://research.cs.wisc.edu/htcondor/repo/9.0/htcondor-release-current.el7.noarch.rpm
+RUN dnf install -y https://research.cs.wisc.edu/htcondor/repo/10/10.0/htcondor-release-current.el8.noarch.rpm
 
-RUN yum -y install epel-release && yum clean all
-RUN yum -y install condor \
-                   python36 \
+RUN dnf -y install epel-release && dnf clean all
+RUN dnf config-manager --set-enabled powertools
+RUN dnf -y install condor \
+                   python39 \
                    ansible \
                    apptainer \
-                   tsocks \
                    openssh-server.x86_64 \
-     && yum clean all
+     && dnf clean all
 
 # Get a newer Git version to use Git Protocol v2
-RUN yum -y install https://packages.endpointdev.com/rhel/7/os/x86_64/endpoint-repo-1.10-1.x86_64.rpm \
-    && yum-config-manager --disable endpoint \
-    && yum -y install --enablerepo endpoint git \
+RUN dnf -y install https://packages.endpointdev.com/rhel/8/main/x86_64/endpoint-repo.noarch.rpm \
+    && dnf config-manager --disable endpoint \
+    && dnf -y install --enablerepo endpoint git \
     && yum clean all
 
-RUN python3.6 -m pip install --no-cache-dir condor_git_config pexpect
+RUN python3.9 -m pip install --no-cache-dir condor_git_config pexpect
 
 # Add ansible community collection
 RUN ansible-galaxy collection install community.general -p /usr/share/ansible/collections

--- a/htcondor-wn/Dockerfile
+++ b/htcondor-wn/Dockerfile
@@ -32,7 +32,7 @@ RUN dnf -y install condor \
 RUN dnf -y install https://packages.endpointdev.com/rhel/8/main/x86_64/endpoint-repo.noarch.rpm \
     && dnf config-manager --disable endpoint \
     && dnf -y install --enablerepo endpoint git \
-    && yum clean all
+    && dnf clean all
 
 RUN python3.9 -m pip install --no-cache-dir condor_git_config pexpect
 

--- a/htcondor-wn/ansible_config/roles/htcondor/tasks/main.yaml
+++ b/htcondor-wn/ansible_config/roles/htcondor/tasks/main.yaml
@@ -1,8 +1,8 @@
-- include: var_lib_dirs.yaml
-- include: config.yaml
-- include: password_auth.yaml
-  when: 
+- include_tasks: var_lib_dirs.yaml
+- include_tasks: config.yaml
+- include_tasks: password_auth.yaml
+  when:
     - HTCONDOR_POOL_PASSWORD is defined
-- include: token_auth.yaml
+- include_tasks: token_auth.yaml
   when:
     - HTCONDOR_TOKEN is defined or HTCONDOR_TOKEN_PASSWORD is defined


### PR DESCRIPTION
This pull request upgrades the htcondor-wn to use RockyLinux 8 and HTCondor 10.

- [x] Update OS to Rocky Linux 8
- [x] Replace all `yum`commands by the appropiate `dnf` commands
- [x] Upgrade HTCondor to version 10
- [x] Remove `tsocks` package, since it is not used and not anymore supported on RHEL8
- [x] Exchange deprecated `include` by `include_task` in the ansible roles
- [x] Test image on HoreKa